### PR TITLE
Correct address to link as a directory top

### DIFF
--- a/src/main/java/com/github/dakusui/mddoclet/MarkdownPage.java
+++ b/src/main/java/com/github/dakusui/mddoclet/MarkdownPage.java
@@ -176,7 +176,7 @@ public class MarkdownPage {
                                 typeNameOf(typeElement),
                                 typeNameOf(typeElement)));
       } else if (element instanceof PackageElement) {
-        sb.append(String.format("- **%s:** [%s](%s/README.md)%n",
+        sb.append(String.format("- **%s:** [%s](%s/)%n",
                                 element.getKind(),
                                 packageNameOf(element, docletEnvironment.getElementUtils()),
                                 packageNameOf(element, docletEnvironment.getElementUtils())));


### PR DESCRIPTION
Correct address to link as a directory top from dirname/README.md to dirname.
