### PR TITLE
Issue-#12: Introduce "package filter" feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
             <groupId>com.github.dakusui</groupId>
             <artifactId>thincrest-pcond</artifactId>
             <version>${thincrest-pcond.version}</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 
@@ -306,16 +307,19 @@
                     <docletArtifact>
                         <groupId>com.github.dakusui</groupId>
                         <artifactId>mddoclet</artifactId>
-                        <version>1.0.0-SNAPSHOT</version>
+                        <version>1.0.4-SNAPSHOT</version>
                     </docletArtifact>
                     <useStandardDocletOptions>false</useStandardDocletOptions>
                     <additionalOptions>
                         <additionalOption>-overview ${project.basedir}/src/main/javadoc/overview.md</additionalOption>
                         <additionalOption>-d ${project.build.outputDirectory}/JavaMarkdown</additionalOption>
                         <additionalOption>--source-path ${project.build.sourceDirectory}</additionalOption>
-                        <additionalOption>--class-path ${project.build.outputDirectory}</additionalOption>
                         <additionalOption>-base-path ${project.build.outputDirectory}/JavaMarkdown</additionalOption>
+                        <additionalOption>-target-packages '.*#.*mddoclet.*'</additionalOption>
                     </additionalOptions>
+                    <additionalJOptions>
+                        <additionalOption>-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005</additionalOption>
+                    </additionalJOptions>
                     <skip>true</skip>
                 </configuration>
                 <executions>
@@ -497,7 +501,7 @@
             </activation>
         </profile>
         <profile>
-            <id>generate-javadocs</id>
+            <id>generate-javadoc</id>
             <build>
                 <plugins>
                     <plugin>

--- a/src/build_tools/options
+++ b/src/build_tools/options
@@ -7,6 +7,8 @@ com.github.dakusui.mddoclet='./src/main/java:./target/generated-sources/annotati
 -doclet
 'com.github.dakusui.mddoclet.MdDoclet'
 -docletpath
+'./target/mddoclet-1.0.4-SNAPSHOT.jar'
+-classpath
 './target/mddoclet-1.0.4-SNAPSHOT.jar:~/.m2/repository/com/github/dakusui/thincrest-pcond/1.1.0/thincrest-pcond-1.1.0.jar:~/.m2/repository/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar'
 -encoding
 'UTF-8'
@@ -14,7 +16,6 @@ com.github.dakusui.mddoclet='./src/main/java:./target/generated-sources/annotati
 './src/main/javadoc/overview.md'
 -protected
 -d ./target/classes/JavaMarkdown
---source-path ./src/main/java
---class-path ./target/classes
 -base-path target/classes/JavaMarkdown
+-target-packages '.*#.*mddoclet.*'
 

--- a/src/main/java/com/github/dakusui/mddoclet/MarkdownPage.java
+++ b/src/main/java/com/github/dakusui/mddoclet/MarkdownPage.java
@@ -1,5 +1,6 @@
 package com.github.dakusui.mddoclet;
 
+import com.github.dakusui.thincrest_pcond.forms.Printables;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.doctree.DocTree;
 import com.sun.source.util.DocTrees;
@@ -16,6 +17,7 @@ import static java.util.stream.Collectors.joining;
 
 public class MarkdownPage {
   private final PageStyle pageStyle;
+  private final Element targetElement;
   private String overview = null;
   
   
@@ -44,10 +46,12 @@ public class MarkdownPage {
   private String title;
   private final Function<String, String> docResolver;
   
-  MarkdownPage(PageStyle pageStyle, DocletEnvironment docletEnvironment, Function<String, String> docResolver) {
-    this.pageStyle = pageStyle;
+  MarkdownPage(Element targetElement, DocletEnvironment docletEnvironment, Function<String, String> docResolver) {
+    this.pageStyle = pageStyleFor(targetElement);
+    this.targetElement = targetElement;
     this.docletEnvironment = docletEnvironment;
     this.docResolver = docResolver;
+    System.out.println(Printables.function("hello", Function.identity()));
   }
   
   public MarkdownPage title(ElementKind kind, String name) {
@@ -62,6 +66,7 @@ public class MarkdownPage {
     return this;
   }
   
+  @SuppressWarnings("UnusedReturnValue")
   public MarkdownPage overview(String overview) {
     this.overview = overview;
     return this;
@@ -160,6 +165,12 @@ public class MarkdownPage {
                                 .collect(joining(", ")));
   }
   
+  private static MarkdownPage.PageStyle pageStyleFor(Element element) {
+    return element instanceof TypeElement
+           ? MarkdownPage.PageStyle.TYPE
+           : MarkdownPage.PageStyle.INDEX;
+  }
+  
   private static String returnTypeOf(ExecutableElement element) {
     String returnType;
     if (element.getKind() != ElementKind.CONSTRUCTOR) {
@@ -203,6 +214,8 @@ public class MarkdownPage {
     
     sb.append(String.format("# Enclosed Elements%n"));
     for (Element element : children) {
+      if (!Objects.equals(this.targetElement, element.getEnclosingElement()))
+        continue;
       if (element instanceof TypeElement typeElement) {
         sb.append(String.format("- **%s:** [%s](%s.md)%n",
                                 element.getKind(),


### PR DESCRIPTION
- Introduce -target-packages option, whose value looks like: .*#.*mddoclet.*, which means "enclosing module name should match .* and the package name should match .*mddoclet.*.
- By default, all the packages will be processed.