### PR TITLE
Fix a bug in non-English character handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
+                    <encoding>UTF-8</encoding>
                     <doclet>com.github.dakusui.mddoclet.MdDoclet</doclet>
                     <docletArtifact>
                         <groupId>com.github.dakusui</groupId>
@@ -317,9 +318,6 @@
                         <additionalOption>-base-path ${project.build.outputDirectory}/JavaMarkdown</additionalOption>
                         <additionalOption>-target-packages '.*#.*mddoclet.*'</additionalOption>
                     </additionalOptions>
-                    <additionalJOptions>
-                        <additionalOption>-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005</additionalOption>
-                    </additionalJOptions>
                     <skip>true</skip>
                 </configuration>
                 <executions>
@@ -508,6 +506,23 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
+                            <skip>false</skip> <!-- Enable Javadoc generation -->
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>debug-javadoc</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalJOptions>
+                                <additionalOption>-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005</additionalOption>
+                            </additionalJOptions>
                             <skip>false</skip> <!-- Enable Javadoc generation -->
                         </configuration>
                     </plugin>

--- a/src/main/java/com/github/dakusui/mddoclet/MdDoclet.java
+++ b/src/main/java/com/github/dakusui/mddoclet/MdDoclet.java
@@ -151,16 +151,15 @@ public class MdDoclet implements Doclet {
    *
    * On a call of this method, the doclet generates markdown based document.
    * ```java
-   * @Retention(RUNTIME)
-   * public class Main {
-   *   public static void main(String... args) {
-   *     System.out.println("Hello!);
-   *   }
-   * }
-   * ```
    *
    * @param docEnv from which essential information can be extracted
    * @return {@code true} on success.
+   * @Retention(RUNTIME) public class Main {
+   * public static void main(String... args) {
+   * System.out.println("Hello!);
+   * }
+   * }
+   * ```
    */
   @Override
   public boolean run(DocletEnvironment docEnv) {
@@ -306,8 +305,11 @@ public class MdDoclet implements Doclet {
       return packageElement.getQualifiedName()
                            .toString();
     } else if (element instanceof ModuleElement moduleElement) {
-      return moduleElement.getQualifiedName()
-                          .toString();
+      var moduleName = moduleElement.getQualifiedName()
+                                    .toString();
+      return !moduleName.isEmpty()
+             ? moduleName
+             : "unnamed";
     }
     return element.toString();
   }

--- a/src/main/java/com/github/dakusui/mddoclet/example/ExampleClass.java
+++ b/src/main/java/com/github/dakusui/mddoclet/example/ExampleClass.java
@@ -1,9 +1,11 @@
 package com.github.dakusui.mddoclet.example;
 
 /**
- * Hello, I am example class.
- * How are you?
- * I am implementing {@link ExampleInterface}.
+ * Hello, I am the first example class.
+ *
+ * Hallo!
+ * こんにちは! How are you?
+ * I am implementing `ExampleInterface`.
  *
  * @see ExampleInterface
  * @link <a href="http://www.example.com">...</a>

--- a/src/main/java/com/github/dakusui/mddoclet/example/package-info.md
+++ b/src/main/java/com/github/dakusui/mddoclet/example/package-info.md
@@ -1,0 +1,4 @@
+An example package of the **mddoclet**.
+
+Hello, world!
+こんにちは世界!


### PR DESCRIPTION
- Convert unicode formatted characters into normal java characters using Properties#{put,get}.
- Specify chartset to write in explicitly and in the pom.xml for safety (basically, this doesn't fix the problem by itself, though).
- Improve a handling of unnamed module name.